### PR TITLE
feat(EIDOMNI-228): Add environment variable to enforce data integrity check

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,4 @@
 # Using java executed in JVM in a pod we should not be affected
 CVE-2025-7425
+# We do not use rar in our application and no attacker should have access to the deployed pod CLI
+CVE-2025-5914

--- a/README.md
+++ b/README.md
@@ -322,6 +322,14 @@ To provide a data integrity check with the issuer it is possible to provide the 
 See [CredentialOfferCreateJWTIT.java](issuer-application/src/test/java/ch/admin/bj/swiyu/issuer/management/infrastructure/web/controller/CredentialOfferCreateJwtIT.java)
 for examples on how to use.
 
+The keys are also set with the environment variable `JWKS_ALLOWLIST`.
+
+The Data integrity check can be enforced to be always used by setting the environment variable.
+
+| Variable                 | Description                                                                                                                               |
+|:-------------------------|:------------------------------------------------------------------------------------------------------------------------------------------|
+| DATA_INTEGRITY_ENFORCED  | Enforce to always do the data integrity check. This will break all existing offers which have been offered without data integrity check!  |
+
 #### Kubernetes Vault Keys
 
 | Variable                                             | Description                                                                                                                                         |

--- a/issuer-application/src/main/resources/application.yml
+++ b/issuer-application/src/main/resources/application.yml
@@ -135,6 +135,7 @@ application:
 
   # List of Json Web Keys which are whitelisted to have signed the offer data
   data-integrity-jwks: ${JWKS_ALLOWLIST:}
+  data-integrity-enforced: ${DATA_INTEGRITY_ENFORCED:false} # If set to true, requires *ALL* saved offers to use data integrity.
   key:
     sdjwt:
       # Method of signing key management

--- a/issuer-service/src/main/java/ch/admin/bj/swiyu/issuer/common/config/ApplicationProperties.java
+++ b/issuer-service/src/main/java/ch/admin/bj/swiyu/issuer/common/config/ApplicationProperties.java
@@ -15,6 +15,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.validation.annotation.Validated;
@@ -92,16 +93,17 @@ public class ApplicationProperties {
     private int nonceLifetimeSeconds;
 
     private String dataIntegrityJwks;
-
-    public JWKSet getDataIntegrityKeySet() throws ParseException {
-        return JWKSet.parse(dataIntegrityJwks);
-    }
+    private JWKSet dataIntegrityKeySet;
+    private boolean dataIntegrityEnforced;
 
     @PostConstruct
     public void init() {
         try {
             if (enableJwtAuthentication) {
                 allowedKeySet = JWKSet.parse(authenticationJwks);
+            }
+            if (StringUtils.isNotBlank(dataIntegrityJwks)) {
+                dataIntegrityKeySet = JWKSet.parse(dataIntegrityJwks);
             }
         } catch (ParseException e) {
             log.error("Provided Allow JWKSet can not be parsed! %s".formatted(authenticationJwks));

--- a/issuer-service/src/main/java/ch/admin/bj/swiyu/issuer/service/DataIntegrityService.java
+++ b/issuer-service/src/main/java/ch/admin/bj/swiyu/issuer/service/DataIntegrityService.java
@@ -57,7 +57,7 @@ public class DataIntegrityService {
         if (offerData == null || !offerData.containsKey("data")) {
             log.error(String.format("Issuer Management Error - Offer %s lacks any offer data", offerIdentifier));
             throw new BadRequestException("No offer data found");
-        } else if (offerData.containsKey("data_integrity")) {
+        } else if (offerData.containsKey("data_integrity") || applicationProperties.isDataIntegrityEnforced()) {
             // Data Integrity Checks
             try {
                 SignedJWT dataIntegrityJWT = SignedJWT.parse((String) offerData.get("data"));

--- a/issuer-service/src/test/java/ch/admin/bj/swiyu/issuer/service/DataIntegrityServiceTest.java
+++ b/issuer-service/src/test/java/ch/admin/bj/swiyu/issuer/service/DataIntegrityServiceTest.java
@@ -1,0 +1,108 @@
+package ch.admin.bj.swiyu.issuer.service;
+
+import ch.admin.bj.swiyu.issuer.common.config.ApplicationProperties;
+import ch.admin.bj.swiyu.issuer.common.exception.BadRequestException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DataIntegrityServiceTest {
+
+    private static ECKey ecKey = null;
+    private DataIntegrityService dataIntegrityService;
+    private ApplicationProperties applicationProperties;
+    private ObjectMapper objectMapper;
+
+    @BeforeAll
+    static void init() throws JOSEException {
+        ecKey = new ECKeyGenerator(Curve.P_256).keyID("123").generate();
+    }
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        applicationProperties = mock(ApplicationProperties.class);
+        when(applicationProperties.getDataIntegrityKeySet()).thenReturn(new JWKSet(ecKey.toPublicJWK()));
+
+        dataIntegrityService = new DataIntegrityService(applicationProperties, objectMapper);
+    }
+
+    @Test
+    void testMissingData_thenFailure() {
+        var exception = Assertions.assertThrows(BadRequestException.class, () -> dataIntegrityService.getVerifiedOfferData(null, null));
+        Assertions.assertEquals("No offer data found", exception.getMessage());
+    }
+
+    @Test
+    void testUnsignedData_thenSuccess() {
+        Map<String, Object> offerData = getTestData();
+        when(applicationProperties.isDataIntegrityEnforced()).thenReturn(false);
+        var unpackedData = Assertions.assertDoesNotThrow(() -> dataIntegrityService.getVerifiedOfferData(wrapTestData(offerData), null));
+        Assertions.assertTrue(offerData.keySet().containsAll(unpackedData.keySet()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testMissingSignatureData_whenEnforced_thenFailure(boolean informDataIntegrity) throws JsonProcessingException {
+        var offerData = wrapTestData(getTestData());
+        if (informDataIntegrity) {
+            offerData.put("data_integrity", "jwt");
+        }
+        when(applicationProperties.isDataIntegrityEnforced()).thenReturn(true);
+        var exception = Assertions.assertThrows(BadRequestException.class, () -> dataIntegrityService.getVerifiedOfferData(offerData, null));
+        Assertions.assertEquals("Invalid serialized unsecured/JWS/JWE object: Missing part delimiters", exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testSignedData_whenEnforced_thenSuccess(boolean informDataIntegrity) throws ParseException, JOSEException {
+        var offerData = getTestData();
+        var wrappedData = wrapTestDataSigned(offerData, ecKey);
+        if (informDataIntegrity) {
+            wrappedData.put("data_integrity", "jwt");
+        }
+        when(applicationProperties.isDataIntegrityEnforced()).thenReturn(true);
+        var unpackedData = Assertions.assertDoesNotThrow(() -> dataIntegrityService.getVerifiedOfferData(wrappedData, null));
+        Assertions.assertTrue(offerData.keySet().containsAll(unpackedData.keySet()));
+    }
+
+    private Map<String, Object> getTestData() {
+        return Map.of("hello", 1, "world", 2);
+    }
+
+    private Map<String, Object> wrapTestData(Map<String, Object> data) throws JsonProcessingException {
+        Map<String, Object> wrapped = new HashMap<>();
+        wrapped.put("data", objectMapper.writeValueAsString(data));
+        return wrapped;
+    }
+
+    private Map<String, Object> wrapTestDataSigned(Map<String, Object> data, ECKey key) throws ParseException, JOSEException {
+        var jwt = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(key.getKeyID()).build(), JWTClaimsSet.parse(data));
+        jwt.sign(new ECDSASigner(key));
+        Map<String, Object> wrapped = new HashMap<>();
+        wrapped.put("data", jwt.serialize());
+        return wrapped;
+    }
+}


### PR DESCRIPTION
Having a data integrity check is nice to know that issued data was not accidentally altered. 
A motivated attacker with access to the database is though able to remove the entire offer data along with the data_integrity entry. This allows to circumvent the optional data integrity check.

Add new environment variable `DATA_INTEGRITY_ENFORCED` (default false) to enforce the data integrity check to be always made.
Activating this will cause the issuer to always check the data integrity of offers. Any offers which are not sent as JWTs will be broken and can not anymore be redeemed!
