### PR TITLE
fix: change jwk to did:jwk in docker sample

### DIFF
--- a/sample.compose.yml
+++ b/sample.compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "5434:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U issuer_mgmt_user -d issuer_db"]
+      test: [ "CMD-SHELL", "pg_isready -U issuer_mgmt_user -d issuer_db" ]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/sample.compose.yml
+++ b/sample.compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "5434:5432"
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U issuer_mgmt_user -d issuer_db" ]
+      test: ["CMD-SHELL", "pg_isready -U issuer_mgmt_user -d issuer_db"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -99,7 +99,7 @@ configs:
           "my-test-vc": {
             "format": "vc+sd-jwt",
             "cryptographic_binding_methods_supported": [
-              "jwk"
+              "did:jwk"
             ],
             "credential_signing_alg_values_supported": [
               "ES256"


### PR DESCRIPTION
Hey,

I was testing the issuer and noticed that when I make a credential offers, they are not accepted in android wallet, but works in ios wallet, after some debugging I found out that android wallet does not support jwk directly, but [did:jwk](https://github.com/swiyu-admin-ch/eidch-android-wallet/blob/7c44157dd3676cb8ca204d7c0ccf5af0750f8f76/openid4vc/src/main/java/ch/admin/foitt/openid4vc/domain/usecase/implementation/GetVerifiableCredentialParamsImpl.kt#L69).
