### PR TITLE
fix(EIDOMNI-870): Use constant time function for nonce comparison

### DIFF
--- a/issuer-service/src/main/java/ch/admin/bj/swiyu/issuer/common/crypto/HashUtil.java
+++ b/issuer-service/src/main/java/ch/admin/bj/swiyu/issuer/common/crypto/HashUtil.java
@@ -2,6 +2,7 @@ package ch.admin.bj.swiyu.issuer.common.crypto;
 
 
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Base64;
 
 import org.bouncycastle.crypto.digests.SHA256Digest;
@@ -31,5 +32,16 @@ public class HashUtil {
         byte[] hmacOut = new byte[hmac.getMacSize()];
         hmac.doFinal(hmacOut, 0);
         return Base64.getUrlEncoder().withoutPadding().encodeToString(hmacOut);
+    }
+
+    /**
+     * Compares the digests of two strings in a time 
+     * constant manner preventing timing attack
+     * @param digestA
+     * @param digestB
+     * @return true if both are equal
+     */
+    public static boolean equalsConstantTime(String digestA, String digestB) {
+        return MessageDigest.isEqual(digestA.getBytes(StandardCharsets.UTF_8), digestB.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/issuer-service/src/main/java/ch/admin/bj/swiyu/issuer/domain/openid/credentialrequest/holderbinding/SelfContainedNonce.java
+++ b/issuer-service/src/main/java/ch/admin/bj/swiyu/issuer/domain/openid/credentialrequest/holderbinding/SelfContainedNonce.java
@@ -133,7 +133,7 @@ public class SelfContainedNonce {
      */
     private static boolean hasInvalidSignature(SelfContainedNonce nonce, IssuerSecret secret) {
         var calculatedSignature = createSignature(nonce.preNonce, secret);
-        return !(calculatedSignature.equals(nonce.nonceSignature));
+        return !HashUtil.equalsConstantTime(nonce.nonceSignature, calculatedSignature);
     }
 
     private static UUID parseNonceId(String[] components) {


### PR DESCRIPTION
A fix using the time constant Message Digest function.

Note - This may have been a false positive in the pen-testing; 
It is always comparing 2 sha-256 - by definition 256 bit of data. A timing attack would not work in that case.