### PR TITLE
Bump Node-20 actions to Node-24 SHAs, add on:push trigger

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -1,6 +1,11 @@
 name: Pull Request Check
-run-name: ${{ github.repository }} is evaluating pull request
-on: [ pull_request ]
+run-name: ${{ github.repository }} is evaluating ${{ github.event_name == 'pull_request' && 'pull request' || format('push to {0}', github.ref_name) }}
+on:
+  pull_request:
+  # Also run on push to main so CodeQL / PMD findings populate the
+  # Security tab for the default branch (GitHub Actions warns otherwise).
+  push:
+    branches: [main]
 
 # Cancel superseded runs on the same PR to save CI minutes.
 concurrency:
@@ -20,14 +25,14 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: java
           config-file: ./.github/codeql/codeql-config.yml
       - name: Set up Java
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -41,7 +46,7 @@ jobs:
       - name: Build & test with Maven (produce JaCoCo)
         run: mvn --batch-mode clean verify -DskipTests=false
       - name: Upload JaCoCo reports
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jacoco-reports
           path: |
@@ -50,7 +55,7 @@ jobs:
             verifier-application/target/site/jacoco/jacoco.xml
             verifier-application/target/site/jacoco/index.html
       - name: Setup Node.js (for coverage summary script)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       - name: Add coverage to summary


### PR DESCRIPTION
Two GitHub Actions deprecation warnings appear on every run of `.github/workflows/pull-request-check.yml`:

1. **Node.js 20 deprecation.** `actions/checkout` (v4), `actions/setup-java` (v4), `actions/upload-artifact` (v4) and `actions/setup-node` (v4) still ship Node 20. GitHub forces Node 24 on 2026-06-16 and removes Node 20 on 2026-09-16.
2. **No `on: push` trigger.** Workflow runs only on `pull_request`, so CodeQL / PMD findings from `main` never reach the Security tab.

Dependabot's actions group on this repo auto-closed twice (#372, #381) and the current one (#391) covers only `snyk/actions` + `github/codeql-action` — none of the four Node-20 SHAs above. The bumps are not arriving through Dependabot.

### Changes

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 `34e11487` | v6.0.3 `df4cb1c0` |
| `actions/setup-java` | v4 `c1e32368` | v5.2.0 `be666c2f` |
| `actions/upload-artifact` | v4 `ea165f8d` | v7.0.1 `043fb46d` |
| `actions/setup-node` | v4 `49933ea5` | v6.4.0 `48b55a01` |

Each target SHA verified via the GitHub API to match its claimed release tag and to declare `using: node24` in `action.yml`. Also adds `on: push: branches: [main]`.

### Follow-up commit: event-agnostic `run-name`

A second commit on this branch addresses Copilot's inline finding on the original revision: once the workflow also runs on push to main, the hard-coded `is evaluating pull request` string is misleading for push runs. Swapped for a ternary on `github.event_name`:

```yaml
run-name: ${{ github.repository }} is evaluating
  ${{ github.event_name == 'pull_request' && 'pull request'
      || format('push to {0}', github.ref_name) }}
```

Reads as `is evaluating pull request` on PR runs and `is evaluating push to main` on push runs. Follows the dynamic-substitution precedent already in `retag-latest.yml`.

### Scope

- `pmd/pmd-github-action` stays at `v2.0.0 d9c1f3c5` — upstream `main` is still `using: node20` with no Node-24 release yet.
- Docker-based actions (Snyk, `docker/*`) unaffected by the Node-20 deprecation.
- `docker-builder.yml` is out of scope.

### Validation

`actionlint 1.7.7` — zero warnings (parity with `origin/main`). YAML parses cleanly with both `pull_request` and `push` triggers present.

### Note on the previous revision

A prior revision of this branch also removed `"github-actions"` from the `dependabot.yml` labels list (it was reported as missing in #372's Dependabot run). That label has since been created in the repo and is now applied by Dependabot itself (e.g. on #391), so the hunk was obsolete and has been dropped. This PR is now strictly a workflow-file change.
